### PR TITLE
aggiunta API che fornisce samples di AKP

### DIFF
--- a/summarization/src/it/unimib/disco/summarization/experiments/SparqlEndpoint.java
+++ b/summarization/src/it/unimib/disco/summarization/experiments/SparqlEndpoint.java
@@ -17,6 +17,10 @@ public class SparqlEndpoint{
 		return new SparqlEndpoint("http://abstat.disco.unimib.it");
 	}
 	
+	public static SparqlEndpoint external(String host){
+		return new SparqlEndpoint(host);
+	}
+	
 	private String host;
 
 	private SparqlEndpoint(String host){

--- a/summarization/src/it/unimib/disco/summarization/export/WriteAKPToRDF.java
+++ b/summarization/src/it/unimib/disco/summarization/export/WriteAKPToRDF.java
@@ -34,6 +34,14 @@ public class WriteAKPToRDF {
 		LDSummariesVocabulary vocabulary = new LDSummariesVocabulary(model, dataset);
 		RDFTypeOf typeOf = new RDFTypeOf(domain);
 		
+		File doc;
+		FileOutputStream fos;
+		if(type.equals("object"))
+			doc = new File("URI-object-akp.txt");
+		else
+			doc = new File("URI-datatype-akp.txt");
+		fos= new FileOutputStream(doc, true);
+		
 		for (Row row : readCSV(csvFilePath)){
 
 			try{
@@ -71,12 +79,18 @@ public class WriteAKPToRDF {
 				model.add(akpInstance, RDF.type, vocabulary.abstractKnowledgePattern());
 				model.add(akpInstance, RDF.type, internal);
 				model.add(akpInstance, vocabulary.occurrence(), statistic);
+				
+				String content = akpInstance.getURI()+"$"+row.get(Row.Entry.SUBJECT)+"$"+row.get(Row.Entry.PREDICATE)+"$"+row.get(Row.Entry.OBJECT)+"\n";
+				byte[] stringa = content.getBytes();
+				fos.write(stringa);
 			}
 			catch(Exception e){
 				Events.summarization().error("file" + csvFilePath + " row" + row, e);
 			}
 
 		}
+		fos.close();
+		
 		OutputStream output = new FileOutputStream(outputFilePath);
 		model.write( output, "N-Triples", null ); // or "RDF/XML", etc.
 

--- a/summarization/src/it/unimib/disco/summarization/export/WriteAKPToRDF.java
+++ b/summarization/src/it/unimib/disco/summarization/export/WriteAKPToRDF.java
@@ -34,14 +34,6 @@ public class WriteAKPToRDF {
 		LDSummariesVocabulary vocabulary = new LDSummariesVocabulary(model, dataset);
 		RDFTypeOf typeOf = new RDFTypeOf(domain);
 		
-		File doc;
-		FileOutputStream fos;
-		if(type.equals("object"))
-			doc = new File("URI-object-akp.txt");
-		else
-			doc = new File("URI-datatype-akp.txt");
-		fos= new FileOutputStream(doc, true);
-		
 		for (Row row : readCSV(csvFilePath)){
 
 			try{
@@ -79,17 +71,12 @@ public class WriteAKPToRDF {
 				model.add(akpInstance, RDF.type, vocabulary.abstractKnowledgePattern());
 				model.add(akpInstance, RDF.type, internal);
 				model.add(akpInstance, vocabulary.occurrence(), statistic);
-				
-				String content = akpInstance.getURI()+"$"+row.get(Row.Entry.SUBJECT)+"$"+row.get(Row.Entry.PREDICATE)+"$"+row.get(Row.Entry.OBJECT)+"\n";
-				byte[] stringa = content.getBytes();
-				fos.write(stringa);
 			}
 			catch(Exception e){
 				Events.summarization().error("file" + csvFilePath + " row" + row, e);
 			}
 
 		}
-		fos.close();
 		
 		OutputStream output = new FileOutputStream(outputFilePath);
 		model.write( output, "N-Triples", null ); // or "RDF/XML", etc.

--- a/summarization/src/it/unimib/disco/summarization/web/Application.java
+++ b/summarization/src/it/unimib/disco/summarization/web/Application.java
@@ -46,7 +46,8 @@ public class Application extends AbstractHandler{
 		routes
 			.mapJson("/api/v1/autocomplete/concepts", new SolrAutocomplete(new SolrConnector(), "concept-suggest"))
 			.mapJson("/api/v1/autocomplete/properties", new SolrAutocomplete(new SolrConnector(), "property-suggest"))
-			.mapJson("/api/v1/datasets", new Datasets(new File("../data/summaries")));
+			.mapJson("/api/v1/datasets", new Datasets(new File("../data/summaries")))
+			.mapJson("/api/v1/sample", new Sample());
 	}
 
 	private void experiment(Routing routes) {

--- a/summarization/src/it/unimib/disco/summarization/web/Sample.java
+++ b/summarization/src/it/unimib/disco/summarization/web/Sample.java
@@ -1,0 +1,103 @@
+package it.unimib.disco.summarization.web;
+
+import com.hp.hpl.jena.query.*;
+import java.io.*;
+
+import it.unimib.disco.summarization.dataset.FileSystemConnector;
+import it.unimib.disco.summarization.dataset.TextInput;
+
+public class Sample implements Api {
+	
+	public InputStream get(RequestParameters request) throws Exception{
+		String endpoint = request.get("endpoint");
+		String akpURI = request.get("akp");
+		
+		File file = new File("URI-object-akp.txt");
+		FileInputStream fis= new FileInputStream(file);
+		
+		String queryString = null;
+		TextInput iteratorFile = new TextInput(new FileSystemConnector(file));
+		boolean trovato = false;
+		
+		while(iteratorFile.hasNextLine() && !trovato){
+			String line = iteratorFile.nextLine();
+			queryString = buildQuery(line, akpURI, "object");
+			if(queryString != null)	
+				trovato = true;
+		}
+		fis.close();
+		
+		if(!trovato){	
+			file = new File("URI-datatype-akp.txt");
+			fis= new FileInputStream(file);
+			iteratorFile = new TextInput(new FileSystemConnector(file));
+			
+			while(iteratorFile.hasNextLine() && !trovato){
+				String line = iteratorFile.nextLine();
+				queryString = buildQuery(line, akpURI, "datatype");
+				if(queryString != null)
+					trovato = true;
+			}
+			fis.close();
+		}
+		
+		Query query = QueryFactory.create(queryString);
+		QueryExecution qexec = QueryExecutionFactory.sparqlService(endpoint, query);
+		ResultSet results = qexec.execSelect();
+		
+		ByteArrayOutputStream out = new ByteArrayOutputStream();	
+		ResultSetFormatter.outputAsJSON(out, results);	
+		byte[] data = out.toByteArray();
+		ByteArrayInputStream istream = new ByteArrayInputStream(data);
+		
+		return istream;
+		
+	}
+		
+	public String buildQuery(String line, String s, String type) {
+		int k = line.indexOf("$");
+		String URI = line.substring(0, k);
+		
+		if(!URI.equals(s))
+			return null;
+		
+		else{
+			line = line.substring(k+1);  //elimino uri
+			k = line.indexOf("$");
+			String sogg = line.substring(0, k);
+			line = line.substring(k+1);  //elimino sogg
+			k = line.indexOf("$");
+			String pred = line.substring(0, k);
+			String ogg = line.substring(k+1);  //elimino pred e rimane l'ogg
+			String query = null;
+			
+			if(type.equals("object")){
+				query = "SELECT * " +
+					    "WHERE {" +
+					    "       ?s ?p ?o."+
+						"       ?s a <" + sogg + ">." +
+						"       ?o a <" + ogg + ">." +
+						"       ?s <" + pred + "> ?o." +
+						"      }LIMIT 30";
+			}
+			else if (!ogg.equals("http://www.w3.org/2000/01/rdf-schema#Literal")){
+				query = "SELECT * " +
+						"WHERE {" +
+						"       ?s ?p ?o."+
+						"       ?s a <" + sogg + ">." +
+						"       ?s <" + pred + "> ?o." +
+						"       FILTER(regex(str(datatype(?o)), \"" + ogg + "\"))"+
+						"      }LIMIT 30";
+			}
+			else {
+				query = "SELECT * " +
+						"WHERE {" +
+						"       ?s ?p ?o."+
+						"       ?s a <" + sogg + ">." +
+						"       ?s <" + pred + "> ?o." +
+						"      }LIMIT 30";
+			}
+			return query;
+		}
+	}
+}

--- a/summarization/src/it/unimib/disco/summarization/web/Sample.java
+++ b/summarization/src/it/unimib/disco/summarization/web/Sample.java
@@ -13,9 +13,8 @@ public class Sample implements Api {
 		String[] tripla_info = getAKP(akpURI);
 		String queryString = buildQuery(tripla_info);
 		
-		Query query = QueryFactory.create(queryString);
-		QueryExecution qexec = QueryExecutionFactory.sparqlService(endpoint, query);
-		ResultSet results = qexec.execSelect();
+		SparqlEndpoint  externalEndpoint = SparqlEndpoint.external(endpoint);
+		ResultSet results = externalEndpoint.execute(queryString);
 		
 		ByteArrayOutputStream out = new ByteArrayOutputStream();	
 		ResultSetFormatter.outputAsJSON(out, results);
@@ -25,78 +24,44 @@ public class Sample implements Api {
 		return istream;
 	}
 	
-	public static String[] getAKP(String akpURI) {
+	private String[] getAKP(String akpURI) {
 		SparqlEndpoint localEndpoint = SparqlEndpoint.local();
 		ResultSet results;
-		int i, l, j, k;
-		String[] array = new String[3];
-		String[] tripla = new String[4];  //conterrà sogg, pred, ogg e property_type
+		String[] tripla_info = new String[4];  //conterrà sogg, pred, ogg e property_type
 		String property_type = "";
 		
+		String query = ("SELECT ?s ?p ?o ?predicate " +
+						"WHERE { " +
+						"		<" + akpURI + ">" + 
+						"						<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> ?subject;" + 
+						"						<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> ?predicate;" +
+						"						<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> ?object." + 
+						"		?subject <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?s." + 
+						"		?predicate <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?p." +
+						"		?object <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o." +
+						"		}");
 		
-		results = localEndpoint.execute("DESCRIBE <" + akpURI + ">");
-		String result = ResultSetFormatter.asText(results); 
+		results = localEndpoint.execute(query);
+		QuerySolution solution = results.nextSolution();
+		tripla_info[0] = solution.get("s").toString();
+		tripla_info[1] = solution.get("p").toString();
+		tripla_info[2] = solution.get("o").toString();
+		tripla_info[3] = solution.get("predicate").toString();
 		
-		
-		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject>");
-		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject>".length();
-		String temp = result.substring(i+l);
-		j = temp.indexOf('<'); k = temp.indexOf('>');
-		array[0] = temp.substring(j, k+1);
-		
-		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate>");
-		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate>".length();
-		temp = result.substring(i+l);
-		j = temp.indexOf('<'); k = temp.indexOf('>');
-		array[1] = temp.substring(j, k+1);
-		
-		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#object>");
-		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#object>".length();
-		temp = result.substring(i+l);
-		j = temp.indexOf('<'); k = temp.indexOf('>');
-		array[2] = temp.substring(j, k+1);
-		
-		
-		if (array[2].contains("/www.w3.org/2000/01/rdf-schema#Literal"))
+		if (tripla_info[2].contains("/www.w3.org/2000/01/rdf-schema#Literal"))
 			property_type = "datatype-property_Literal";
-		else if ( array[1].contains("datatype-property"))
-			property_type = "datatype";
+		else if (tripla_info[3].contains("datatype-property"))
+			property_type = "datatype-property";
 		else
 			property_type = "object-property";
-		tripla[3] = property_type;
 		
+		tripla_info[3] = property_type;
 		
-		
-		results = localEndpoint.execute("SELECT ?o " +
-									 	 "WHERE { "   +
-									 	 array[0] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
-										 "}");
-		String res = ResultSetFormatter.asText(results);
-		j = res.indexOf('<'); k = res.indexOf('>');
-		tripla[0] = res.substring(j+1, k);
-		
-		results = localEndpoint.execute("SELECT ?o " +
-									 	 "WHERE { "   +
-									 	 array[1] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
-										 "}");
-		res = ResultSetFormatter.asText(results);
-		j = res.indexOf('<'); k = res.indexOf('>');
-		tripla[1] = res.substring(j+1, k);
-		
-		results = localEndpoint.execute("SELECT ?o " +
-			 	 						"WHERE { "   +
-			 	 						array[2] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
-				 						"}");
-		res = ResultSetFormatter.asText(results);
-		j = res.indexOf('<'); k = res.indexOf('>');
-		tripla[2] = res.substring(j+1, k);
-	
-		return tripla;
+		return tripla_info;
 	}
 	
-	
 		
-	public String buildQuery(String[] tripla_info) {
+	private String buildQuery(String[] tripla_info) {
 		String query;
 		if(tripla_info[3].equals("object-property")){
 			query = "SELECT DISTINCT ?s ?p ?o " +
@@ -124,6 +89,7 @@ public class Sample implements Api {
 					"       BIND( <"+ tripla_info[1] + "> AS ?p)." +
 					"      }LIMIT 30";
 		}
+		
 		return query;
 	}
 }

--- a/summarization/src/it/unimib/disco/summarization/web/Sample.java
+++ b/summarization/src/it/unimib/disco/summarization/web/Sample.java
@@ -2,9 +2,7 @@ package it.unimib.disco.summarization.web;
 
 import com.hp.hpl.jena.query.*;
 import java.io.*;
-
-import it.unimib.disco.summarization.dataset.FileSystemConnector;
-import it.unimib.disco.summarization.dataset.TextInput;
+import it.unimib.disco.summarization.experiments.SparqlEndpoint;
 
 public class Sample implements Api {
 	
@@ -12,92 +10,120 @@ public class Sample implements Api {
 		String endpoint = request.get("endpoint");
 		String akpURI = request.get("akp");
 		
-		File file = new File("URI-object-akp.txt");
-		FileInputStream fis= new FileInputStream(file);
-		
-		String queryString = null;
-		TextInput iteratorFile = new TextInput(new FileSystemConnector(file));
-		boolean trovato = false;
-		
-		while(iteratorFile.hasNextLine() && !trovato){
-			String line = iteratorFile.nextLine();
-			queryString = buildQuery(line, akpURI, "object");
-			if(queryString != null)	
-				trovato = true;
-		}
-		fis.close();
-		
-		if(!trovato){	
-			file = new File("URI-datatype-akp.txt");
-			fis= new FileInputStream(file);
-			iteratorFile = new TextInput(new FileSystemConnector(file));
-			
-			while(iteratorFile.hasNextLine() && !trovato){
-				String line = iteratorFile.nextLine();
-				queryString = buildQuery(line, akpURI, "datatype");
-				if(queryString != null)
-					trovato = true;
-			}
-			fis.close();
-		}
+		String[] tripla_info = getAKP(akpURI);
+		String queryString = buildQuery(tripla_info);
 		
 		Query query = QueryFactory.create(queryString);
 		QueryExecution qexec = QueryExecutionFactory.sparqlService(endpoint, query);
 		ResultSet results = qexec.execSelect();
 		
 		ByteArrayOutputStream out = new ByteArrayOutputStream();	
-		ResultSetFormatter.outputAsJSON(out, results);	
+		ResultSetFormatter.outputAsJSON(out, results);
 		byte[] data = out.toByteArray();
 		ByteArrayInputStream istream = new ByteArrayInputStream(data);
 		
 		return istream;
-		
 	}
+	
+	public static String[] getAKP(String akpURI) {
+		SparqlEndpoint localEndpoint = SparqlEndpoint.local();
+		ResultSet results;
+		int i, l, j, k;
+		String[] array = new String[3];
+		String[] tripla = new String[4];  //conterrà sogg, pred, ogg e property_type
+		String property_type = "";
 		
-	public String buildQuery(String line, String s, String type) {
-		int k = line.indexOf("$");
-		String URI = line.substring(0, k);
 		
-		if(!URI.equals(s))
-			return null;
+		results = localEndpoint.execute("DESCRIBE <" + akpURI + ">");
+		String result = ResultSetFormatter.asText(results); 
 		
-		else{
-			line = line.substring(k+1);  //elimino uri
-			k = line.indexOf("$");
-			String sogg = line.substring(0, k);
-			line = line.substring(k+1);  //elimino sogg
-			k = line.indexOf("$");
-			String pred = line.substring(0, k);
-			String ogg = line.substring(k+1);  //elimino pred e rimane l'ogg
-			String query = null;
-			
-			if(type.equals("object")){
-				query = "SELECT * " +
-					    "WHERE {" +
-					    "       ?s ?p ?o."+
-						"       ?s a <" + sogg + ">." +
-						"       ?o a <" + ogg + ">." +
-						"       ?s <" + pred + "> ?o." +
-						"      }LIMIT 30";
-			}
-			else if (!ogg.equals("http://www.w3.org/2000/01/rdf-schema#Literal")){
-				query = "SELECT * " +
-						"WHERE {" +
-						"       ?s ?p ?o."+
-						"       ?s a <" + sogg + ">." +
-						"       ?s <" + pred + "> ?o." +
-						"       FILTER(regex(str(datatype(?o)), \"" + ogg + "\"))"+
-						"      }LIMIT 30";
-			}
-			else {
-				query = "SELECT * " +
-						"WHERE {" +
-						"       ?s ?p ?o."+
-						"       ?s a <" + sogg + ">." +
-						"       ?s <" + pred + "> ?o." +
-						"      }LIMIT 30";
-			}
-			return query;
+		
+		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject>");
+		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject>".length();
+		String temp = result.substring(i+l);
+		j = temp.indexOf('<'); k = temp.indexOf('>');
+		array[0] = temp.substring(j, k+1);
+		
+		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate>");
+		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate>".length();
+		temp = result.substring(i+l);
+		j = temp.indexOf('<'); k = temp.indexOf('>');
+		array[1] = temp.substring(j, k+1);
+		
+		i = result.indexOf("<http://www.w3.org/1999/02/22-rdf-syntax-ns#object>");
+		l = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#object>".length();
+		temp = result.substring(i+l);
+		j = temp.indexOf('<'); k = temp.indexOf('>');
+		array[2] = temp.substring(j, k+1);
+		
+		
+		if (array[2].contains("/www.w3.org/2000/01/rdf-schema#Literal"))
+			property_type = "datatype-property_Literal";
+		else if ( array[1].contains("datatype-property"))
+			property_type = "datatype";
+		else
+			property_type = "object-property";
+		tripla[3] = property_type;
+		
+		
+		
+		results = localEndpoint.execute("SELECT ?o " +
+									 	 "WHERE { "   +
+									 	 array[0] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
+										 "}");
+		String res = ResultSetFormatter.asText(results);
+		j = res.indexOf('<'); k = res.indexOf('>');
+		tripla[0] = res.substring(j+1, k);
+		
+		results = localEndpoint.execute("SELECT ?o " +
+									 	 "WHERE { "   +
+									 	 array[1] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
+										 "}");
+		res = ResultSetFormatter.asText(results);
+		j = res.indexOf('<'); k = res.indexOf('>');
+		tripla[1] = res.substring(j+1, k);
+		
+		results = localEndpoint.execute("SELECT ?o " +
+			 	 						"WHERE { "   +
+			 	 						array[2] + " <http://www.w3.org/2000/01/rdf-schema#seeAlso> ?o" +
+				 						"}");
+		res = ResultSetFormatter.asText(results);
+		j = res.indexOf('<'); k = res.indexOf('>');
+		tripla[2] = res.substring(j+1, k);
+	
+		return tripla;
+	}
+	
+	
+		
+	public String buildQuery(String[] tripla_info) {
+		String query;
+		if(tripla_info[3].equals("object-property")){
+			query = "SELECT DISTINCT ?s ?p ?o " +
+				    "WHERE {" +
+					"       ?s a <" + tripla_info[0] + ">." +
+					"       ?o a <" + tripla_info[2] + ">." +
+					"       ?s <" + tripla_info[1] + "> ?o." +
+					"       BIND( <"+ tripla_info[1] + "> AS ?p)." +
+					"      }LIMIT 30";
 		}
+		else if (!tripla_info[3].equals("datatype-property_Literal")){
+			query = "SELECT DISTINCT ?s ?p ?o " +
+					"WHERE {" +
+					"       ?s a <" + tripla_info[0] + ">." +
+					"       ?s <" + tripla_info[1] + "> ?o." +
+					"       BIND( <"+ tripla_info[1] + "> AS ?p)." +
+					"       FILTER(regex(str(datatype(?o)), \"" + tripla_info[2] + "\"))"+
+					"      }LIMIT 30";
+		}
+		else {
+			query = "SELECT DISTINCT ?s ?p ?o " +
+					"WHERE {" +
+					"       ?s a <" + tripla_info[0] + ">." +
+					"       ?s <" + tripla_info[1] + "> ?o." +
+					"       BIND( <"+ tripla_info[1] + "> AS ?p)." +
+					"      }LIMIT 30";
+		}
+		return query;
 	}
 }

--- a/summarization/test/it/unimib/disco/summarization/test/system/SampleAPITest.java
+++ b/summarization/test/it/unimib/disco/summarization/test/system/SampleAPITest.java
@@ -1,0 +1,40 @@
+package it.unimib.disco.summarization.test.system;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.Test;
+
+import it.unimib.disco.summarization.test.web.HttpAssert;
+
+public class SampleAPITest {
+	
+	@Test
+	public void shouldWorkWithObjectAKPs() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/6c3d3badd793d15e6da3677886389818", containsString("\"o\": { \"type\": \"uri\" , \"value\":"));
+	}
+	
+	@Test
+	public void shouldWorkWithLiteralDatatypeAKPs() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/a1792e5711c7ac1207b7d5a7d5a993c3", containsString("\"o\": { \"type\": \"literal\""));
+	}
+	
+	@Test
+	public void shouldWorkWithDatatypeAKPs() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/7fa4ad0b5be445410d925b412d25dedc", containsString("\"o\": { \"datatype\":"));
+	}
+	
+	@Test
+	public void sampleShouldShowSubject() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/6c3d3badd793d15e6da3677886389818", containsString("\"s\":"));
+	}
+	
+	@Test
+	public void sampleShouldShowPredicate() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/6c3d3badd793d15e6da3677886389818", containsString("\"p\":"));
+	}
+	
+	@Test
+	public void sampleShouldShowObject() throws Exception {
+		new HttpAssert("http://localhost").body("/api/v1/sample?endpoint=http://dbpedia.org/sparql&akp=http://ld-summaries.org/resource/system-test/AKP/6c3d3badd793d15e6da3677886389818", containsString("\"o\":"));
+	}
+}


### PR DESCRIPTION
Sono statate modificate 3 classi.

/summarization/export/writeAKPToRDF: 
ho fatto in modo che venga scritto su file(URI-object-akp.txt e URI-datatype-akp.txt) l'elenco degli AKP con la loro URI, soggetto, predicato e oggetto.

summarization/web/Application: 
aggiunge la rotta per /api/v1/sample

summarization/web/Sample:
classe che implementa l'interfaccia Api. Estrae dalla richiesta i parametri "endpoint" e "akp", dopodichè ricerca "akp" nei file URI-object-akp.txt e URI-datatype-akp.txt. Una volta trovato viene costruita la query tramite buildQuery(). Successivamente viene fatta la query SPARQL all'endpoint "endpoint" e il risultato ritornato al chiamante. 